### PR TITLE
Fix: Fix streamingUri typo in Readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ const options = {
         customizedProperties: []
     },
     sdkKey: 'YOUR ENVIRONMENT SECRET',
-    streamingUrl: 'THE STREAMING URL',
+    streamingUri: 'THE STREAMING URL',
     eventsUrl: 'THE EVENTS URL'
 };
 
@@ -133,7 +133,7 @@ const options = {
         customizedProperties: []
     },
     sdkKey: 'YOUR ENVIRONMENT SECRET',
-    streamingUrl: 'THE STREAMING URL',
+    streamingUri: 'THE STREAMING URL',
     eventsUrl: 'THE EVENTS URL'
 };
 


### PR DESCRIPTION
## Fix: Correct `streamingUrl` to `streamingUri` in README  

### Issue  
While integrating **@featbit/react-native-sdk**, I followed the example in the README. After debugging, I found that the **js-client-sdk** uses `streamingUri`, while the README incorrectly refers to it as `streamingUrl`.  

### Fix  
- Updated the README to use `streamingUri` for consistency with the SDK implementation.  