### PR TITLE
Bump @featbit/react-client-sdk to 4.2.15 (propagate js-client-sdk WebSocket fixes to RN)

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "@featbit/react-client-sdk": "4.2.9",
+    "@featbit/react-client-sdk": "4.2.15",
     "@react-native-async-storage/async-storage": "^1.23.1"
   }
 }


### PR DESCRIPTION
Closes #5.

`@featbit/react-client-sdk@4.2.15` now depends on `@featbit/js-client-sdk@4.2.15`, which carries the WebSocket fixes from featbit/featbit-js-client-sdk#22 (half-open socket detection) and featbit/featbit-js-client-sdk#23 (reconnect backoff reset).

Those fixes don't reach React Native users until this exact pin is bumped: `react-native-sdk` → `react-client-sdk@4.2.9` → `js-client-sdk@4.2.9` were all exact pins, so a fresh install still resolved the old, unfixed `js-client-sdk`. This is a one-line dependency bump; no code changes.
